### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -96,7 +96,12 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  const staticLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  app.use("*", staticLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/PMDevSolutions/seo-copilot/security/code-scanning/3](https://github.com/PMDevSolutions/seo-copilot/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the route handler that performs the file system access. We can use the `express-rate-limit` package, which is already imported in the file, to create a rate limiter and apply it to the specific route handler.

1. Create a rate limiter with appropriate settings (e.g., maximum of 100 requests per 15 minutes).
2. Apply the rate limiter to the route handler that serves the `index.html` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
